### PR TITLE
Fix Version bubble and base url CSS.

### DIFF
--- a/swagger_ui_formatter/swagger_ui_formatter.css
+++ b/swagger_ui_formatter/swagger_ui_formatter.css
@@ -1,0 +1,4 @@
+/* blocks boostraps pre tag so swagger ui can format it correctly */
+pre {
+  all: initial;
+}

--- a/swagger_ui_formatter/swagger_ui_formatter.info
+++ b/swagger_ui_formatter/swagger_ui_formatter.info
@@ -2,4 +2,4 @@ name = Swagger UI Field Formatter
 description = Provides a field formatter for file fields with Swagger YAML or JSON files uploaded.
 core = 7.x
 package = UCSB
-version = 7.x-2.0-rc1
+version = 7.x-2.0-rc2

--- a/swagger_ui_formatter/swagger_ui_formatter.module
+++ b/swagger_ui_formatter/swagger_ui_formatter.module
@@ -122,6 +122,7 @@ function swagger_ui_formatter_field_formatter_view($entity_type, $entity, $field
     $validator_url = $settings['validator_url'];
   }
 
+  drupal_add_css($module_path . '/swagger_ui_formatter.css', 'file');
   drupal_add_js($module_path . '/swagger_ui_formatter.js', 'file');
   drupal_add_js(array(
     'swagger_ui_formatter' => array(


### PR DESCRIPTION
Adds a css rule to block bootstrap css from corrupting swagger css for the `pre` tag.

This fixed the version bubble and base url box.

Closes #2 

![image](https://user-images.githubusercontent.com/4443025/37774881-a16620a4-2d9e-11e8-88a8-dc4d715766dc.png)
